### PR TITLE
Suggested changes for pimatic 0.9 readiness

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,11 +8,11 @@
   "private": true,
   "dependencies": {
     "angular": "^1.5.5",
-    "angular-material": "~0.11",
+    "angular-material": "^0.11.4",
     "angular-messages": "^1.5.5",
     "angular-route": "^1.5.5",
-    "angular-translate": "~2.8.0",
-    "mdi": "~1",
+    "angular-translate": "~2.11.0",
+    "mdi": "^1.5.54",
     "socket.io-client": "~1"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Pimatic AngularJS frontend",
+  "name": "pimatic-angular-frontend",
   "version": "0.2.1",
   "authors": [
     "Dennis Schroer <dennisschroer@hotmail.com>"

--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,10 @@
   "description": "Responsive frontend for pimatic, written using AngularJS",
   "private": true,
   "dependencies": {
-    "angular": "~1",
+    "angular": "^1.5.5",
     "angular-material": "~0.11",
-    "angular-messages": "~1",
-    "angular-route": "~1",
+    "angular-messages": "^1.5.5",
+    "angular-route": "^1.5.5",
     "angular-translate": "~2.8.0",
     "mdi": "~1",
     "socket.io-client": "~1"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pimatic-angular-material-frontend",
   "description": "Provides an AngularJS webinterface for Pimatic with material design.",
   "author": "Dennis Schroer <mail@dennisschroer.nl> (http://dennisschroer.nl)",
+  "license": "GPL-3.0",
   "main": "angular-material-frontend.coffee",
   "keywords": ["pimatic"],
   "files": [
@@ -24,31 +25,34 @@
     "type": "git",
     "url": "git://github.com/denniss17/pimatic-angular-material-frontend.git"
   },
+  "bugs": {
+     "url": "git://github.com/denniss17/pimatic-angular-material-frontend/issues"
+  },
   "configSchema": "angular-material-frontend-config-schema.coffee",
   "bundledDependencies": [],
   "dependencies": {
     "bower": "^1.5.1"
   },
   "peerDependencies": {
-    "pimatic": "0.8.* && >=0.8.31"
+    "pimatic": ">=0.8.31"
   },
   "engines": {
     "node": ">0.8.x",
     "npm": ">1.1.x"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-jshint": "^0.11.2",
-    "grunt-contrib-uglify": "^0.9.1",
+    "grunt": "^1.0.1",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-uglify": "^1.0.1",
     "grunt-karma": "^0.12.0",
-    "grunt-replace": "^0.11.0",
+    "grunt-replace": "^1.0.1",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.9",
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^0.2.1",
-    "phantomjs": "^1.9.18"
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs": "^2.1.7"
   },
   "scripts": {
     "postinstall": "bower install -p --allow-root"


### PR DESCRIPTION
Some changes are required to run the plugin with pimatic0.9. The essential changes are 
- Plugin for pimatic 0.9 shall contain a valid license tags as part of the package descriptor
- Updated angualr dependencies to get rid of post-installation errors (bower package installation)
- Updated pimatic peerDepencency to run with pimatic 0.9

Please review the changes carefully. I haven't tested with pimatic0.8. So, I am not sure changes are backwards compatible. I have noticed a glitch: When a toast message is displayed (running in debug at the moment, so I see many toast messages) the vertical scrollbar is display for time the toast message is visible.
